### PR TITLE
Add single image segmentation script and macOS usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,16 @@ To train the model with densenet model:
 ```python train.py --model densenet --expname FINAL --bs 8 --useGPU True --dataset Semantic_Segmentation_Dataset/```
 
 To test the result:
- 
+
 ```python test.py --model densenet --load best_model.pkl --bs 4 --dataset Semantic_Segmentation_Dataset/```
+
+To segment a single image on macOS (CPU by default):
+
+```bash
+pip install -r requirements.txt
+python segment_image.py --image path/to/eye.png --output mask.png --weights best_model.pkl
+```
+Add `--useGPU` to enable CUDA if available; if CUDA isn't found the script will fall back to CPU.
 
 
 # Contents in the zip folder

--- a/segment_image.py
+++ b/segment_image.py
@@ -1,0 +1,69 @@
+import argparse
+import os
+
+import numpy as np
+import torch
+from PIL import Image
+import cv2
+import matplotlib.pyplot as plt
+
+from dataset import transform
+from models import model_dict
+from utils import get_predictions
+
+
+def preprocess_image(path: str) -> torch.Tensor:
+    """Load and preprocess an image for RITnet.
+
+    This function mirrors the preprocessing used during training/test.
+    The input image is converted to grayscale, gamma corrected, and
+    contrast limited adaptive histogram equalization (CLAHE) is applied
+    before normalizing to a tensor.
+    """
+    pilimg = Image.open(path).convert("L")
+
+    # Gamma correction with factor 0.8
+    table = 255.0 * (np.linspace(0, 1, 256) ** 0.8)
+    pilimg = cv2.LUT(np.array(pilimg), table)
+
+    # CLAHE
+    clahe = cv2.createCLAHE(clipLimit=1.5, tileGridSize=(8, 8))
+    img = clahe.apply(np.array(np.uint8(pilimg)))
+    img = Image.fromarray(img)
+
+    # Normalize to tensor
+    img = transform(img)
+    return img.unsqueeze(0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Segment a single eye image using RITnet.")
+    parser.add_argument("--image", required=True, help="Path to the input image")
+    parser.add_argument("--output", default="segmentation.png", help="Path to save the predicted mask")
+    parser.add_argument("--weights", default="best_model.pkl", help="Path to model weights")
+    parser.add_argument("--model", default="densenet", choices=list(model_dict.keys()), help="Model architecture")
+    parser.add_argument("--useGPU", action="store_true", help="Use GPU if available")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if args.useGPU and torch.cuda.is_available() else "cpu")
+    if args.useGPU and not torch.cuda.is_available():
+        print("CUDA not available, falling back to CPU")
+    print(f"Using device: {device}")
+
+    net = model_dict[args.model].to(device)
+    state = torch.load(args.weights, map_location=device)
+    net.load_state_dict(state)
+    net.eval()
+
+    img = preprocess_image(args.image).to(device)
+
+    with torch.no_grad():
+        pred = net(img)
+        mask = get_predictions(pred)[0].cpu().numpy()
+
+    plt.imsave(args.output, mask)
+    print(f"Saved segmentation mask to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `segment_image.py` to run RITnet on a single image and save its segmentation mask
- document how to run the new script on macOS in the README
- warn when CUDA is requested but unavailable and clarify CPU fallback

## Testing
- `python -m py_compile segment_image.py`
- `pip install torch torchvision pillow opencv-python-headless matplotlib tqdm numpy` *(fails: Could not find a version that satisfies the requirement torch)*
- `python segment_image.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a3d3b2f21c832a8a0dc7f42b2da07d